### PR TITLE
Add support for deparsing AST expression nodes

### DIFF
--- a/parser/include/pg_query.h
+++ b/parser/include/pg_query.h
@@ -118,6 +118,7 @@ PgQuerySplitResult pg_query_split_with_scanner(const char *input);
 PgQuerySplitResult pg_query_split_with_parser(const char *input);
 
 PgQueryDeparseResult pg_query_deparse_protobuf(PgQueryProtobuf parse_tree);
+PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf parse_tree);
 
 void pg_query_free_normalize_result(PgQueryNormalizeResult result);
 void pg_query_free_scan_result(PgQueryScanResult result);

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -16,6 +16,14 @@ PgQueryDeparseResult pg_query_deparse_protobuf_direct_args(void* data, unsigned 
 	return pg_query_deparse_protobuf(p);
 }
 
+// Avoid complexities dealing with C structs in Go
+PgQueryDeparseResult pg_query_deparse_expr_protobuf_direct_args(void* data, unsigned int len) {
+	PgQueryProtobuf p;
+	p.data = (char *) data;
+	p.len = len;
+	return pg_query_deparse_expr_protobuf(p);
+}
+
 // Avoid inconsistent type behaviour in xxhash library
 uint64_t pg_query_hash_xxh3_64(void *data, size_t len, size_t seed) {
 	return XXH3_64bits_withSeed(data, len, seed);
@@ -125,6 +133,24 @@ func DeparseFromProtobuf(input []byte) (result string, err error) {
 	defer C.free(inputC)
 
 	resultC := C.pg_query_deparse_protobuf_direct_args(inputC, C.uint(len(input)))
+
+	defer C.pg_query_free_deparse_result(resultC)
+
+	if resultC.error != nil {
+		err = newPgQueryError(resultC.error)
+		return
+	}
+
+	result = C.GoString(resultC.query)
+
+	return
+}
+
+func DeparseExprFromProtobuf(input []byte) (result string, err error) {
+	inputC := C.CBytes(input)
+	defer C.free(inputC)
+
+	resultC := C.pg_query_deparse_expr_protobuf_direct_args(inputC, C.uint(len(input)))
 
 	defer C.pg_query_free_deparse_result(resultC)
 

--- a/parser/pg_query_deparse.c
+++ b/parser/pg_query_deparse.c
@@ -54,6 +54,52 @@ PgQueryDeparseResult pg_query_deparse_protobuf(PgQueryProtobuf parse_tree)
 	return result;
 }
 
+PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf expr)
+{
+	PgQueryDeparseResult result = {0};
+	StringInfoData str;
+	MemoryContext ctx;
+	Node *node;
+
+	ctx = pg_query_enter_memory_context();
+
+	PG_TRY();
+	{
+		node = pg_query_protobuf_to_node(expr);
+
+		initStringInfo(&str);
+
+		deparseExpr(&str, node);
+
+		result.query = strdup(str.data);
+	}
+	PG_CATCH();
+	{
+		ErrorData* error_data;
+		PgQueryError* error;
+
+		MemoryContextSwitchTo(ctx);
+		error_data = CopyErrorData();
+
+		// Note: This is intentionally malloc so exiting the memory context doesn't free this
+		error = malloc(sizeof(PgQueryError));
+		error->message   = strdup(error_data->message);
+		error->filename  = strdup(error_data->filename);
+		error->funcname  = strdup(error_data->funcname);
+		error->context   = NULL;
+		error->lineno	= error_data->lineno;
+		error->cursorpos = error_data->cursorpos;
+
+		result.error = error;
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pg_query_exit_memory_context(ctx);
+
+	return result;
+}
+
 void pg_query_free_deparse_result(PgQueryDeparseResult result)
 {
 	if (result.error) {

--- a/parser/pg_query_readfuncs.h
+++ b/parser/pg_query_readfuncs.h
@@ -7,5 +7,6 @@
 #include "nodes/pg_list.h"
 
 List * pg_query_protobuf_to_nodes(PgQueryProtobuf protobuf);
+Node * pg_query_protobuf_to_node(PgQueryProtobuf protobuf);
 
 #endif

--- a/parser/pg_query_readfuncs_protobuf.c
+++ b/parser/pg_query_readfuncs_protobuf.c
@@ -175,3 +175,19 @@ List * pg_query_protobuf_to_nodes(PgQueryProtobuf protobuf)
 
 	return list;
 }
+
+
+Node * pg_query_protobuf_to_node(PgQueryProtobuf protobuf)
+{
+	PgQuery__Node * result;
+
+	result = pg_query__node__unpack(NULL, protobuf.len, (const uint8_t *) protobuf.data);
+
+	// TODO: Handle this by returning an error instead
+	Assert(result != NULL);
+
+	// TODO: Handle this by returning an error instead
+	Assert(result->version == PG_VERSION_NUM);
+
+	return _readNode(result);
+}

--- a/parser/postgres_deparse.c
+++ b/parser/postgres_deparse.c
@@ -140,6 +140,7 @@ static void deparseIntoClause(StringInfo str, IntoClause *into_clause);
 static void deparseRangeVar(StringInfo str, RangeVar *range_var, DeparseNodeContext context);
 static void deparseResTarget(StringInfo str, ResTarget *res_target, DeparseNodeContext context);
 void deparseRawStmt(StringInfo str, RawStmt *raw_stmt);
+void deparseExpr(StringInfo str, Node *node);
 static void deparseAlias(StringInfo str, Alias *alias);
 static void deparseWindowDef(StringInfo str, WindowDef* window_def);
 static void deparseColumnRef(StringInfo str, ColumnRef* column_ref);
@@ -313,7 +314,7 @@ static void deparseFuncExpr(StringInfo str, Node *node)
 static void deparseCExpr(StringInfo str, Node *node);
 
 // "a_expr" in gram.y
-static void deparseExpr(StringInfo str, Node *node)
+void deparseExpr(StringInfo str, Node *node)
 {
 	if (node == NULL)
 		return;

--- a/parser/postgres_deparse.h
+++ b/parser/postgres_deparse.h
@@ -5,5 +5,6 @@
 #include "nodes/parsenodes.h"
 
 extern void deparseRawStmt(StringInfo str, RawStmt *raw_stmt);
+extern void deparseExpr(StringInfo str, Node *node);
 
 #endif

--- a/pg_query.go
+++ b/pg_query.go
@@ -47,6 +47,17 @@ func Deparse(tree *ParseResult) (output string, err error) {
 	return
 }
 
+// Deparses a an expression into a SQL statement
+func DeparseExpr(node *Node) (output string, err error) {
+	protobufNode, err := proto.Marshal(node)
+	if err != nil {
+		return
+	}
+
+	output, err = parser.DeparseExprFromProtobuf(protobufNode)
+	return
+}
+
 // ParsePlPgSqlToJSON - Parses the given PL/pgSQL function statement into a parse tree (JSON format)
 func ParsePlPgSqlToJSON(input string) (result string, err error) {
 	return parser.ParsePlPgSqlToJSON(input)


### PR DESCRIPTION
Extend the Go API with a new function:

```go
func DeparseExpr(node *Node) (output string, err error) {
  ...
}
```

`DeparseExpr` deparses an expression node (an `a_expr` in the Postgres grammar) to a string. This new function sits alongside the existing `Deparse` function:

```go
func Deparse(tree *ParseResult) (output string, err error) {
  ...
}
```

The difference between `DeparseExpr` and `Deparse` is that the latter only supports deparsing complete SQL statements, whereas the former allows deparsing arbitrary subexpressions within a statement.