### PR TITLE
Add support for deparsing AST `TypeName` nodes

### DIFF
--- a/parser/include/pg_query.h
+++ b/parser/include/pg_query.h
@@ -119,6 +119,7 @@ PgQuerySplitResult pg_query_split_with_parser(const char *input);
 
 PgQueryDeparseResult pg_query_deparse_protobuf(PgQueryProtobuf parse_tree);
 PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf parse_tree);
+PgQueryDeparseResult pg_query_deparse_typename_protobuf(PgQueryProtobuf parse_tree);
 
 void pg_query_free_normalize_result(PgQueryNormalizeResult result);
 void pg_query_free_scan_result(PgQueryScanResult result);

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -24,6 +24,14 @@ PgQueryDeparseResult pg_query_deparse_expr_protobuf_direct_args(void* data, unsi
 	return pg_query_deparse_expr_protobuf(p);
 }
 
+// Avoid complexities dealing with C structs in Go
+PgQueryDeparseResult pg_query_deparse_typename_protobuf_direct_args(void* data, unsigned int len) {
+	PgQueryProtobuf p;
+	p.data = (char *) data;
+	p.len = len;
+	return pg_query_deparse_typename_protobuf(p);
+}
+
 // Avoid inconsistent type behaviour in xxhash library
 uint64_t pg_query_hash_xxh3_64(void *data, size_t len, size_t seed) {
 	return XXH3_64bits_withSeed(data, len, seed);
@@ -151,6 +159,24 @@ func DeparseExprFromProtobuf(input []byte) (result string, err error) {
 	defer C.free(inputC)
 
 	resultC := C.pg_query_deparse_expr_protobuf_direct_args(inputC, C.uint(len(input)))
+
+	defer C.pg_query_free_deparse_result(resultC)
+
+	if resultC.error != nil {
+		err = newPgQueryError(resultC.error)
+		return
+	}
+
+	result = C.GoString(resultC.query)
+
+	return
+}
+
+func DeparseTypeNameFromProtobuf(input []byte) (result string, err error) {
+	inputC := C.CBytes(input)
+	defer C.free(inputC)
+
+	resultC := C.pg_query_deparse_typename_protobuf_direct_args(inputC, C.uint(len(input)))
 
 	defer C.pg_query_free_deparse_result(resultC)
 

--- a/parser/pg_query_deparse.c
+++ b/parser/pg_query_deparse.c
@@ -105,17 +105,17 @@ PgQueryDeparseResult pg_query_deparse_typename_protobuf(PgQueryProtobuf expr)
 	PgQueryDeparseResult result = {0};
 	StringInfoData str;
 	MemoryContext ctx;
-  Node *node;
+  TypeName *typename;
 
 	ctx = pg_query_enter_memory_context();
 
 	PG_TRY();
 	{
-		node = pg_query_protobuf_to_node(expr);
+		typename = pg_query_protobuf_to_typename(expr);
 
 		initStringInfo(&str);
 
-    deparseTypeName(&str, castNode(TypeName, node));
+    deparseTypeName(&str, typename);
 
 		result.query = strdup(str.data);
 	}

--- a/parser/pg_query_deparse.c
+++ b/parser/pg_query_deparse.c
@@ -100,6 +100,52 @@ PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf expr)
 	return result;
 }
 
+PgQueryDeparseResult pg_query_deparse_typename_protobuf(PgQueryProtobuf expr)
+{
+	PgQueryDeparseResult result = {0};
+	StringInfoData str;
+	MemoryContext ctx;
+  Node *node;
+
+	ctx = pg_query_enter_memory_context();
+
+	PG_TRY();
+	{
+		node = pg_query_protobuf_to_node(expr);
+
+		initStringInfo(&str);
+
+    deparseTypeName(&str, castNode(TypeName, node));
+
+		result.query = strdup(str.data);
+	}
+	PG_CATCH();
+	{
+		ErrorData* error_data;
+		PgQueryError* error;
+
+		MemoryContextSwitchTo(ctx);
+		error_data = CopyErrorData();
+
+		// Note: This is intentionally malloc so exiting the memory context doesn't free this
+		error = malloc(sizeof(PgQueryError));
+		error->message   = strdup(error_data->message);
+		error->filename  = strdup(error_data->filename);
+		error->funcname  = strdup(error_data->funcname);
+		error->context   = NULL;
+		error->lineno	= error_data->lineno;
+		error->cursorpos = error_data->cursorpos;
+
+		result.error = error;
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pg_query_exit_memory_context(ctx);
+
+	return result;
+}
+
 void pg_query_free_deparse_result(PgQueryDeparseResult result)
 {
 	if (result.error) {

--- a/parser/pg_query_readfuncs.h
+++ b/parser/pg_query_readfuncs.h
@@ -5,8 +5,10 @@
 
 #include "postgres.h"
 #include "nodes/pg_list.h"
+#include "nodes/parsenodes.h"
 
 List * pg_query_protobuf_to_nodes(PgQueryProtobuf protobuf);
 Node * pg_query_protobuf_to_node(PgQueryProtobuf protobuf);
+TypeName * pg_query_protobuf_to_typename(PgQueryProtobuf protobuf);
 
 #endif

--- a/parser/pg_query_readfuncs_protobuf.c
+++ b/parser/pg_query_readfuncs_protobuf.c
@@ -191,3 +191,18 @@ Node * pg_query_protobuf_to_node(PgQueryProtobuf protobuf)
 
 	return _readNode(result);
 }
+
+TypeName * pg_query_protobuf_to_typename(PgQueryProtobuf protobuf)
+{
+    PgQuery__TypeName * result;
+
+    result = pg_query__type_name__unpack(NULL, protobuf.len, (const uint8_t *) protobuf.data);
+
+    // TODO: Handle this by returning an error instead
+    Assert(result != NULL);
+
+    // TODO: Handle this by returning an error instead
+    Assert(result->version == PG_VERSION_NUM);
+
+    return _readTypeName(result);
+}

--- a/parser/postgres_deparse.c
+++ b/parser/postgres_deparse.c
@@ -160,7 +160,7 @@ static void deparseRangeFunction(StringInfo str, RangeFunction *range_func);
 static void deparseAArrayExpr(StringInfo str, A_ArrayExpr * array_expr);
 static void deparseRowExpr(StringInfo str, RowExpr *row_expr);
 static void deparseTypeCast(StringInfo str, TypeCast *type_cast, DeparseNodeContext context);
-static void deparseTypeName(StringInfo str, TypeName *type_name);
+void deparseTypeName(StringInfo str, TypeName *type_name);
 static void deparseIntervalTypmods(StringInfo str, TypeName *type_name);
 static void deparseNullTest(StringInfo str, NullTest *null_test);
 static void deparseCaseExpr(StringInfo str, CaseExpr *case_expr);
@@ -3772,7 +3772,7 @@ static void deparseTypeCast(StringInfo str, TypeCast *type_cast, DeparseNodeCont
 	deparseTypeName(str, type_cast->typeName);
 }
 
-static void deparseTypeName(StringInfo str, TypeName *type_name)
+void deparseTypeName(StringInfo str, TypeName *type_name)
 {
 	ListCell *lc;
 	bool skip_typmods = false;

--- a/parser/postgres_deparse.h
+++ b/parser/postgres_deparse.h
@@ -6,5 +6,6 @@
 
 extern void deparseRawStmt(StringInfo str, RawStmt *raw_stmt);
 extern void deparseExpr(StringInfo str, Node *node);
+extern void deparseTypeName(StringInfo str, TypeName *type_name);
 
 #endif

--- a/pg_query.go
+++ b/pg_query.go
@@ -58,6 +58,16 @@ func DeparseExpr(node *Node) (output string, err error) {
 	return
 }
 
+func DeparseTypeName(typeName *TypeName) (output string, err error) {
+	protobufNode, err := proto.Marshal(typeName)
+	if err != nil {
+		return
+	}
+
+	output, err = parser.DeparseTypeNameFromProtobuf(protobufNode)
+	return
+}
+
 // ParsePlPgSqlToJSON - Parses the given PL/pgSQL function statement into a parse tree (JSON format)
 func ParsePlPgSqlToJSON(input string) (result string, err error) {
 	return parser.ParsePlPgSqlToJSON(input)


### PR DESCRIPTION
Extend the Go API with a new function:

```go
func DeparseTypeName(typeName *TypeName) (output string, err error) {
  ...
}
```

`DeparseTypeName` deparses a `TypeName` node (a `Typename` production in the Postgres grammar) to a string. 

`DeparseTypeName` is implemented by changing the linkage of the `deparseTypeName` function in the C deparser to external and then implementing `cgo` and protobuf serialization/deserialization to be able to call it from Go.

This PR is very similar to #1 which exposed the `deparseExpr` function from the C deparser and made it callable from Go in the same way.