### PR TITLE
Add support for deparsing AST `reloptions` nodes

### DIFF
--- a/parser/include/pg_query.h
+++ b/parser/include/pg_query.h
@@ -120,6 +120,7 @@ PgQuerySplitResult pg_query_split_with_parser(const char *input);
 PgQueryDeparseResult pg_query_deparse_protobuf(PgQueryProtobuf parse_tree);
 PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf parse_tree);
 PgQueryDeparseResult pg_query_deparse_typename_protobuf(PgQueryProtobuf parse_tree);
+PgQueryDeparseResult pg_query_deparse_reloptions_protobuf(PgQueryProtobuf buf);
 
 void pg_query_free_normalize_result(PgQueryNormalizeResult result);
 void pg_query_free_scan_result(PgQueryScanResult result);

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -32,6 +32,14 @@ PgQueryDeparseResult pg_query_deparse_typename_protobuf_direct_args(void* data, 
 	return pg_query_deparse_typename_protobuf(p);
 }
 
+// Avoid complexities dealing with C structs in Go
+PgQueryDeparseResult pg_query_deparse_reloptions_protobuf_direct_args(void* data, unsigned int len) {
+	PgQueryProtobuf p;
+	p.data = (char *) data;
+	p.len = len;
+	return pg_query_deparse_reloptions_protobuf(p);
+}
+
 // Avoid inconsistent type behaviour in xxhash library
 uint64_t pg_query_hash_xxh3_64(void *data, size_t len, size_t seed) {
 	return XXH3_64bits_withSeed(data, len, seed);
@@ -177,6 +185,24 @@ func DeparseTypeNameFromProtobuf(input []byte) (result string, err error) {
 	defer C.free(inputC)
 
 	resultC := C.pg_query_deparse_typename_protobuf_direct_args(inputC, C.uint(len(input)))
+
+	defer C.pg_query_free_deparse_result(resultC)
+
+	if resultC.error != nil {
+		err = newPgQueryError(resultC.error)
+		return
+	}
+
+	result = C.GoString(resultC.query)
+
+	return
+}
+
+func DeparseRelOptionsFromProtobuf(input []byte) (result string, err error) {
+	inputC := C.CBytes(input)
+	defer C.free(inputC)
+
+	resultC := C.pg_query_deparse_reloptions_protobuf_direct_args(inputC, C.uint(len(input)))
 
 	defer C.pg_query_free_deparse_result(resultC)
 

--- a/parser/pg_query_deparse.c
+++ b/parser/pg_query_deparse.c
@@ -146,6 +146,52 @@ PgQueryDeparseResult pg_query_deparse_typename_protobuf(PgQueryProtobuf expr)
 	return result;
 }
 
+PgQueryDeparseResult pg_query_deparse_reloptions_protobuf(PgQueryProtobuf buf)
+{
+	PgQueryDeparseResult result = {0};
+	StringInfoData str;
+	MemoryContext ctx;
+	List *list;
+
+	ctx = pg_query_enter_memory_context();
+
+	PG_TRY();
+	{
+		list = pg_query_protobuf_to_list(buf);
+
+		initStringInfo(&str);
+
+		deparseRelOptions(&str, list);
+
+		result.query = strdup(str.data);
+	}
+	PG_CATCH();
+	{
+		ErrorData* error_data;
+		PgQueryError* error;
+
+		MemoryContextSwitchTo(ctx);
+		error_data = CopyErrorData();
+
+		// Note: This is intentionally malloc so exiting the memory context doesn't free this
+		error = malloc(sizeof(PgQueryError));
+		error->message   = strdup(error_data->message);
+		error->filename  = strdup(error_data->filename);
+		error->funcname  = strdup(error_data->funcname);
+		error->context   = NULL;
+		error->lineno	= error_data->lineno;
+		error->cursorpos = error_data->cursorpos;
+
+		result.error = error;
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pg_query_exit_memory_context(ctx);
+
+	return result;
+}
+
 void pg_query_free_deparse_result(PgQueryDeparseResult result)
 {
 	if (result.error) {

--- a/parser/pg_query_readfuncs.h
+++ b/parser/pg_query_readfuncs.h
@@ -10,5 +10,6 @@
 List * pg_query_protobuf_to_nodes(PgQueryProtobuf protobuf);
 Node * pg_query_protobuf_to_node(PgQueryProtobuf protobuf);
 TypeName * pg_query_protobuf_to_typename(PgQueryProtobuf protobuf);
+List * pg_query_protobuf_to_list(PgQueryProtobuf protobuf);
 
 #endif

--- a/parser/pg_query_readfuncs_protobuf.c
+++ b/parser/pg_query_readfuncs_protobuf.c
@@ -206,3 +206,18 @@ TypeName * pg_query_protobuf_to_typename(PgQueryProtobuf protobuf)
 
     return _readTypeName(result);
 }
+
+List * pg_query_protobuf_to_list(PgQueryProtobuf protobuf)
+{
+    PgQuery__List * result;
+
+    result = pg_query__list__unpack(NULL, protobuf.len, (const uint8_t *) protobuf.data);
+
+    // TODO: Handle this by returning an error instead
+    Assert(result != NULL);
+
+    // TODO: Handle this by returning an error instead
+    Assert(result->version == PG_VERSION_NUM);
+
+    return _readList(result);
+}

--- a/parser/postgres_deparse.c
+++ b/parser/postgres_deparse.c
@@ -1529,7 +1529,7 @@ static void deparseAlterIdentityColumnOptionList(StringInfo str, List *l)
 }
 
 // "reloptions" in gram.y
-static void deparseRelOptions(StringInfo str, List *l)
+void deparseRelOptions(StringInfo str, List *l)
 {
 	ListCell *lc = NULL;
 

--- a/parser/postgres_deparse.h
+++ b/parser/postgres_deparse.h
@@ -7,5 +7,6 @@
 extern void deparseRawStmt(StringInfo str, RawStmt *raw_stmt);
 extern void deparseExpr(StringInfo str, Node *node);
 extern void deparseTypeName(StringInfo str, TypeName *type_name);
+extern void deparseRelOptions(StringInfo str, List *l);
 
 #endif

--- a/pg_query.go
+++ b/pg_query.go
@@ -68,6 +68,18 @@ func DeparseTypeName(typeName *TypeName) (output string, err error) {
 	return
 }
 
+func DeparseRelOptions(relOptions []*Node) (output string, err error) {
+	list := MakeListNode(relOptions)
+
+	protobufNode, err := proto.Marshal(list.GetList())
+	if err != nil {
+		return
+	}
+
+	output, err = parser.DeparseRelOptionsFromProtobuf(protobufNode)
+	return
+}
+
 // ParsePlPgSqlToJSON - Parses the given PL/pgSQL function statement into a parse tree (JSON format)
 func ParsePlPgSqlToJSON(input string) (result string, err error) {
 	return parser.ParsePlPgSqlToJSON(input)


### PR DESCRIPTION
Extend the Go API with a new function:

```go
func DeparseRelOptions(relOptions []*Node) (output string, err error) {
  ...
}
```

`DeparseRelOptions` a `reloptions` production in the Postgres grammar to a string. 

`reloptions` are the option lists used in, for example, `CREATE INDEX` statements:

```sql
CREATE INDEX idx_name ON foo (bar) WITH (fillfactor = 70, deduplicate_items = true)
```

the `(fillfactor = 70, deduplicate_items = true)` part is the `reloptions` list.

`DeparseRelOptions` is implemented by changing the linkage of the `deparseRelOptions` function in the C deparser to external and then implementing `cgo` and protobuf serialization/deserialization to be able to call it from Go.

This PR is very similar to #1 and #2 which exposed the `deparseExpr` and `deparseTypename` functions from the C deparser and made them callable from Go in the same way.