### PR TITLE
Add support for deparsing parenthesized sequence options list

### DIFF
--- a/parser/include/pg_query.h
+++ b/parser/include/pg_query.h
@@ -121,6 +121,7 @@ PgQueryDeparseResult pg_query_deparse_protobuf(PgQueryProtobuf parse_tree);
 PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf parse_tree);
 PgQueryDeparseResult pg_query_deparse_typename_protobuf(PgQueryProtobuf parse_tree);
 PgQueryDeparseResult pg_query_deparse_reloptions_protobuf(PgQueryProtobuf buf);
+PgQueryDeparseResult pg_query_deparse_parenthesized_seq_opt_list_protobuf(PgQueryProtobuf buf);
 
 void pg_query_free_normalize_result(PgQueryNormalizeResult result);
 void pg_query_free_scan_result(PgQueryScanResult result);

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -40,6 +40,14 @@ PgQueryDeparseResult pg_query_deparse_reloptions_protobuf_direct_args(void* data
 	return pg_query_deparse_reloptions_protobuf(p);
 }
 
+// Avoid complexities dealing with C structs in Go
+PgQueryDeparseResult pg_query_deparse_parenthesized_seq_opt_list(void* data, unsigned int len) {
+	PgQueryProtobuf p;
+	p.data = (char *) data;
+	p.len = len;
+	return pg_query_deparse_parenthesized_seq_opt_list_protobuf(p);
+}
+
 // Avoid inconsistent type behaviour in xxhash library
 uint64_t pg_query_hash_xxh3_64(void *data, size_t len, size_t seed) {
 	return XXH3_64bits_withSeed(data, len, seed);
@@ -203,6 +211,24 @@ func DeparseRelOptionsFromProtobuf(input []byte) (result string, err error) {
 	defer C.free(inputC)
 
 	resultC := C.pg_query_deparse_reloptions_protobuf_direct_args(inputC, C.uint(len(input)))
+
+	defer C.pg_query_free_deparse_result(resultC)
+
+	if resultC.error != nil {
+		err = newPgQueryError(resultC.error)
+		return
+	}
+
+	result = C.GoString(resultC.query)
+
+	return
+}
+
+func DeparseParenthesizedSeqOptList(input []byte) (result string, err error) {
+	inputC := C.CBytes(input)
+	defer C.free(inputC)
+
+	resultC := C.pg_query_deparse_parenthesized_seq_opt_list(inputC, C.uint(len(input)))
 
 	defer C.pg_query_free_deparse_result(resultC)
 

--- a/parser/postgres_deparse.c
+++ b/parser/postgres_deparse.c
@@ -678,7 +678,7 @@ static void deparseOptSeqOptList(StringInfo str, List *options)
 }
 
 // "OptParenthesizedSeqOptList" in gram.y
-static void deparseOptParenthesizedSeqOptList(StringInfo str, List *options)
+void deparseOptParenthesizedSeqOptList(StringInfo str, List *options)
 {
 	if (list_length(options) > 0)
 	{

--- a/parser/postgres_deparse.h
+++ b/parser/postgres_deparse.h
@@ -8,5 +8,6 @@ extern void deparseRawStmt(StringInfo str, RawStmt *raw_stmt);
 extern void deparseExpr(StringInfo str, Node *node);
 extern void deparseTypeName(StringInfo str, TypeName *type_name);
 extern void deparseRelOptions(StringInfo str, List *l);
+extern void deparseOptParenthesizedSeqOptList(StringInfo str, List *l);
 
 #endif

--- a/pg_query.go
+++ b/pg_query.go
@@ -80,6 +80,18 @@ func DeparseRelOptions(relOptions []*Node) (output string, err error) {
 	return
 }
 
+func DeparseParenthesizedSeqOptList(seqOptions []*Node) (output string, err error) {
+	list := MakeListNode(seqOptions)
+
+	protobufNode, err := proto.Marshal(list.GetList())
+	if err != nil {
+		return
+	}
+
+	output, err = parser.DeparseParenthesizedSeqOptList(protobufNode)
+	return
+}
+
 // ParsePlPgSqlToJSON - Parses the given PL/pgSQL function statement into a parse tree (JSON format)
 func ParsePlPgSqlToJSON(input string) (result string, err error) {
 	return parser.ParsePlPgSqlToJSON(input)


### PR DESCRIPTION
Extend the Go API with a new function:

```go
func DeparseParenthesizedSeqOptList(seqOptions []*Node) (output string, err error)
```

This function is used to deparse sequence options. Example statement for generating identity columns and setting sequence options:

```sql
ALTER TABLE table1 ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (START 5 INCREMENT 5);
```

the `(START 5 INCREMENT 5)` portion can be deparsed with this new function.

Based on https://github.com/xataio/pg_query_go/pull/6