### PR TITLE
Add DeparseIndexElem and DeparseAnyOperator

### DIFF
--- a/parser/include/pg_query.h
+++ b/parser/include/pg_query.h
@@ -122,6 +122,8 @@ PgQueryDeparseResult pg_query_deparse_expr_protobuf(PgQueryProtobuf parse_tree);
 PgQueryDeparseResult pg_query_deparse_typename_protobuf(PgQueryProtobuf parse_tree);
 PgQueryDeparseResult pg_query_deparse_reloptions_protobuf(PgQueryProtobuf buf);
 PgQueryDeparseResult pg_query_deparse_parenthesized_seq_opt_list_protobuf(PgQueryProtobuf buf);
+PgQueryDeparseResult pg_query_deparse_index_elem_protobuf(PgQueryProtobuf buf);
+PgQueryDeparseResult pg_query_deparse_any_operator_protobuf(PgQueryProtobuf buf);
 
 void pg_query_free_normalize_result(PgQueryNormalizeResult result);
 void pg_query_free_scan_result(PgQueryScanResult result);

--- a/parser/pg_query_deparse.c
+++ b/parser/pg_query_deparse.c
@@ -238,6 +238,98 @@ PgQueryDeparseResult pg_query_deparse_parenthesized_seq_opt_list_protobuf(PgQuer
 	return result;
 }
 
+PgQueryDeparseResult pg_query_deparse_any_operator_protobuf(PgQueryProtobuf buf)
+{
+	PgQueryDeparseResult result = {0};
+	StringInfoData str;
+	MemoryContext ctx;
+	List *list;
+
+	ctx = pg_query_enter_memory_context();
+
+	PG_TRY();
+	{
+		list = pg_query_protobuf_to_list(buf);
+
+		initStringInfo(&str);
+
+		deparseAnyOperator(&str, list);
+
+		result.query = strdup(str.data);
+	}
+	PG_CATCH();
+	{
+		ErrorData* error_data;
+		PgQueryError* error;
+
+		MemoryContextSwitchTo(ctx);
+		error_data = CopyErrorData();
+
+		// Note: This is intentionally malloc so exiting the memory context doesn't free this
+		error = malloc(sizeof(PgQueryError));
+		error->message   = strdup(error_data->message);
+		error->filename  = strdup(error_data->filename);
+		error->funcname  = strdup(error_data->funcname);
+		error->context   = NULL;
+		error->lineno	= error_data->lineno;
+		error->cursorpos = error_data->cursorpos;
+
+		result.error = error;
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pg_query_exit_memory_context(ctx);
+
+	return result;
+}
+
+PgQueryDeparseResult pg_query_deparse_index_elem_protobuf(PgQueryProtobuf buf)
+{
+	PgQueryDeparseResult result = {0};
+	StringInfoData str;
+	MemoryContext ctx;
+	Node *node;
+
+	ctx = pg_query_enter_memory_context();
+
+	PG_TRY();
+	{
+		node = pg_query_protobuf_to_node(buf);
+
+		initStringInfo(&str);
+
+		deparseIndexElem(&str, node);
+
+		result.query = strdup(str.data);
+	}
+	PG_CATCH();
+	{
+		ErrorData* error_data;
+		PgQueryError* error;
+
+		MemoryContextSwitchTo(ctx);
+		error_data = CopyErrorData();
+
+		// Note: This is intentionally malloc so exiting the memory context doesn't free this
+		error = malloc(sizeof(PgQueryError));
+		error->message   = strdup(error_data->message);
+		error->filename  = strdup(error_data->filename);
+		error->funcname  = strdup(error_data->funcname);
+		error->context   = NULL;
+		error->lineno	= error_data->lineno;
+		error->cursorpos = error_data->cursorpos;
+
+		result.error = error;
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pg_query_exit_memory_context(ctx);
+
+	return result;
+}
+
 void pg_query_free_deparse_result(PgQueryDeparseResult result)
 {
 	if (result.error) {

--- a/parser/postgres_deparse.c
+++ b/parser/postgres_deparse.c
@@ -172,7 +172,7 @@ static void deparseBooleanTest(StringInfo str, BooleanTest *boolean_test);
 static void deparseColumnDef(StringInfo str, ColumnDef *column_def);
 static void deparseInsertStmt(StringInfo str, InsertStmt *insert_stmt);
 static void deparseOnConflictClause(StringInfo str, OnConflictClause *on_conflict_clause);
-static void deparseIndexElem(StringInfo str, IndexElem* index_elem);
+void deparseIndexElem(StringInfo str, IndexElem* index_elem);
 static void deparseUpdateStmt(StringInfo str, UpdateStmt *update_stmt);
 static void deparseDeleteStmt(StringInfo str, DeleteStmt *delete_stmt);
 static void deparseLockingClause(StringInfo str, LockingClause *locking_clause);
@@ -703,7 +703,7 @@ static void deparseOptDropBehavior(StringInfo str, DropBehavior behavior)
 }
 
 // "any_operator" in gram.y
-static void deparseAnyOperator(StringInfo str, List *op)
+void deparseAnyOperator(StringInfo str, List *op)
 {
 	Assert(isOp(strVal(llast(op))));
 	if (list_length(op) == 2)
@@ -1933,7 +1933,7 @@ static void deparseOptCollate(StringInfo str, List *l)
 }
 
 // "index_elem" in gram.y
-static void deparseIndexElem(StringInfo str, IndexElem* index_elem)
+void deparseIndexElem(StringInfo str, IndexElem* index_elem)
 {
 	if (index_elem->name != NULL)
 	{

--- a/parser/postgres_deparse.h
+++ b/parser/postgres_deparse.h
@@ -9,5 +9,7 @@ extern void deparseExpr(StringInfo str, Node *node);
 extern void deparseTypeName(StringInfo str, TypeName *type_name);
 extern void deparseRelOptions(StringInfo str, List *l);
 extern void deparseOptParenthesizedSeqOptList(StringInfo str, List *l);
+extern void deparseIndexElem(StringInfo str, Node *node);
+extern void deparseAnyOperator(StringInfo str, List *l);
 
 #endif

--- a/pg_query.go
+++ b/pg_query.go
@@ -92,6 +92,28 @@ func DeparseParenthesizedSeqOptList(seqOptions []*Node) (output string, err erro
 	return
 }
 
+func DeparseIndexElem(node *Node) (output string, err error) {
+	protobufNode, err := proto.Marshal(node)
+	if err != nil {
+		return
+	}
+
+	output, err = parser.DeparseIndexElem(protobufNode)
+	return
+}
+
+func DeparseAnyOperator(anyOp []*Node) (output string, err error) {
+	list := MakeListNode(anyOp)
+
+	protobufNode, err := proto.Marshal(list.GetList())
+	if err != nil {
+		return
+	}
+
+	output, err = parser.DeparseAnyOperator(protobufNode)
+	return
+}
+
 // ParsePlPgSqlToJSON - Parses the given PL/pgSQL function statement into a parse tree (JSON format)
 func ParsePlPgSqlToJSON(input string) (result string, err error) {
 	return parser.ParsePlPgSqlToJSON(input)


### PR DESCRIPTION
In order to deparse the exclusion elements of an exclusion constraint, we need `DeparseIndexElem`s and `DeparseAnyOperator`.

An exclusion element is a column name or function call and an operator. Examples:
* `id WITH =`
* `range(a, b) WITH &&`

Used in https://github.com/xataio/pgroll/pull/624