### PR TITLE
Add `DeparseAnyName` to deparse collation names

### DIFF
--- a/parser/include/pg_query.h
+++ b/parser/include/pg_query.h
@@ -124,6 +124,7 @@ PgQueryDeparseResult pg_query_deparse_reloptions_protobuf(PgQueryProtobuf buf);
 PgQueryDeparseResult pg_query_deparse_parenthesized_seq_opt_list_protobuf(PgQueryProtobuf buf);
 PgQueryDeparseResult pg_query_deparse_index_elem_protobuf(PgQueryProtobuf buf);
 PgQueryDeparseResult pg_query_deparse_any_operator_protobuf(PgQueryProtobuf buf);
+PgQueryDeparseResult pg_query_deparse_any_name_protobuf(PgQueryProtobuf buf);
 
 void pg_query_free_normalize_result(PgQueryNormalizeResult result);
 void pg_query_free_scan_result(PgQueryScanResult result);

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -62,6 +62,13 @@ PgQueryDeparseResult pg_query_deparse_protobuf_any_operator(void* data, unsigned
 	return pg_query_deparse_any_operator_protobuf(p);
 }
 
+PgQueryDeparseResult pg_query_deparse_protobuf_any_name(void* data, unsigned int len) {
+	PgQueryProtobuf p;
+	p.data = (char *) data;
+	p.len = len;
+	return pg_query_deparse_any_name_protobuf(p);
+}
+
 // Avoid inconsistent type behaviour in xxhash library
 uint64_t pg_query_hash_xxh3_64(void *data, size_t len, size_t seed) {
 	return XXH3_64bits_withSeed(data, len, seed);
@@ -279,6 +286,24 @@ func DeparseIndexElem(input []byte) (result string, err error) {
 	defer C.free(inputC)
 
 	resultC := C.pg_query_deparse_protobuf_index_elem(inputC, C.uint(len(input)))
+
+	defer C.pg_query_free_deparse_result(resultC)
+
+	if resultC.error != nil {
+		err = newPgQueryError(resultC.error)
+		return
+	}
+
+	result = C.GoString(resultC.query)
+
+	return
+}
+
+func DeparseAnyName(input []byte) (result string, err error) {
+	inputC := C.CBytes(input)
+	defer C.free(inputC)
+
+	resultC := C.pg_query_deparse_protobuf_any_name(inputC, C.uint(len(input)))
 
 	defer C.pg_query_free_deparse_result(resultC)
 

--- a/parser/pg_query_deparse.c
+++ b/parser/pg_query_deparse.c
@@ -330,6 +330,52 @@ PgQueryDeparseResult pg_query_deparse_index_elem_protobuf(PgQueryProtobuf buf)
 	return result;
 }
 
+PgQueryDeparseResult pg_query_deparse_any_name_protobuf(PgQueryProtobuf buf)
+{
+	PgQueryDeparseResult result = {0};
+	StringInfoData str;
+	MemoryContext ctx;
+	List *parts;
+
+	ctx = pg_query_enter_memory_context();
+
+	PG_TRY();
+	{
+		parts = pg_query_protobuf_to_list(buf);
+
+		initStringInfo(&str);
+
+		deparseAnyName(&str, parts);
+
+		result.query = strdup(str.data);
+	}
+	PG_CATCH();
+	{
+		ErrorData* error_data;
+		PgQueryError* error;
+
+		MemoryContextSwitchTo(ctx);
+		error_data = CopyErrorData();
+
+		// Note: This is intentionally malloc so exiting the memory context doesn't free this
+		error = malloc(sizeof(PgQueryError));
+		error->message   = strdup(error_data->message);
+		error->filename  = strdup(error_data->filename);
+		error->funcname  = strdup(error_data->funcname);
+		error->context   = NULL;
+		error->lineno	= error_data->lineno;
+		error->cursorpos = error_data->cursorpos;
+
+		result.error = error;
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	pg_query_exit_memory_context(ctx);
+
+	return result;
+}
+
 void pg_query_free_deparse_result(PgQueryDeparseResult result)
 {
 	if (result.error) {

--- a/parser/postgres_deparse.c
+++ b/parser/postgres_deparse.c
@@ -227,7 +227,7 @@ static void deparseValue(StringInfo str, union ValUnion *value, DeparseNodeConte
 
 
 // "any_name" in gram.y
-static void deparseAnyName(StringInfo str, List *parts)
+void deparseAnyName(StringInfo str, List *parts)
 {
 	ListCell *lc = NULL;
 

--- a/parser/postgres_deparse.h
+++ b/parser/postgres_deparse.h
@@ -11,5 +11,6 @@ extern void deparseRelOptions(StringInfo str, List *l);
 extern void deparseOptParenthesizedSeqOptList(StringInfo str, List *l);
 extern void deparseIndexElem(StringInfo str, Node *node);
 extern void deparseAnyOperator(StringInfo str, List *l);
+extern void deparseAnyName(StringInfo str, List *l);
 
 #endif

--- a/pg_query.go
+++ b/pg_query.go
@@ -114,6 +114,18 @@ func DeparseAnyOperator(anyOp []*Node) (output string, err error) {
 	return
 }
 
+func DeparseAnyName(anyName []*Node) (output string, err error) {
+	list := MakeListNode(anyName)
+
+	protobufNode, err := proto.Marshal(list.GetList())
+	if err != nil {
+		return
+	}
+
+	output, err = parser.DeparseAnyName(protobufNode)
+	return
+}
+
 // ParsePlPgSqlToJSON - Parses the given PL/pgSQL function statement into a parse tree (JSON format)
 func ParsePlPgSqlToJSON(input string) (result string, err error) {
 	return parser.ParsePlPgSqlToJSON(input)


### PR DESCRIPTION
The call `DeparseAnyName` is used to deparse collation names.

Required by: https://github.com/xataio/pgroll/pull/697